### PR TITLE
Update index.html to fix broken links on running for ANC

### DIFF
--- a/ancfindersite/templates/ancfindersite/index.html
+++ b/ancfindersite/templates/ancfindersite/index.html
@@ -127,7 +127,7 @@
 			<div class="col-sm-5 text">
 				<h2>Who elects ANC commissioners?</h2>
                                 <p>ANC commissioners each represent one single member district (SMD). ANC campaigns are typically small, grassroots efforts. In fact, winning candidates often run unopposed and receive just a few hundred votes.</p>
-                                <p>To run for a seat, a candidate must collect 25 signatures from registered voters in his or her SMD. Visit the DC Board of Elections website to <a href="http://www.dcboee.org/candidate_info/general_info/">learn more about running for ANC commissioner</a>.</p>
+                                <p>To run for a seat, a candidate must collect 25 signatures from registered voters in his or her SMD. Visit the DC Board of Elections website to <a href="https://anc.dc.gov/page/anc-elections">learn more about running for ANC commissioner</a>.</p>
 			</div>
 		</div>
 	</div>
@@ -138,7 +138,7 @@
 		<div class="row">
 			<div class="col-sm-5 col-sm-offset-1 text">
 				<h2>How can I get involved?</h2>
-				<p>To get involved in your ANC, you can attend ANC meetings, learn more about your ANC, or even <a href="http://runforanc.com/">become an ANC Commissioner</a>.</p>
+				<p>To get involved in your ANC, you can attend ANC meetings, learn more about your ANC, or even <a href="https://anc.dc.gov/page/anc-elections">become an ANC Commissioner</a>.</p>
 				<p><a class="smooth" href="#intro">Start by finding your ANC.</a></p>
 			</div>
 			<div class="col-sm-5 image">


### PR DESCRIPTION
Fixes #155 and #156. 

Under "Who elects ANC commissioners?", updated to anc.dc.gov since it seems to have better info than the Board of Elections site currently. 

Under "How can I get involved?", sadly runforanc.com no longer exists, so replacing with the same anc.dc.gov link. 